### PR TITLE
Fix duplicate header newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.1.1 - 2024/06/03
+
+- Fix double newlines for headers (https://github.com/schneems/bullet_stream/pull/2)
+
 ## v0.1.0 - 2024/06/03
 
 - First

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "bullet_stream"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ascii_table",
  "fun_run",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bullet_stream"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Bulletproof printing for bullet point text"


### PR DESCRIPTION
Headers have the same "block syntax" problem as errors/warnings. We can use the same tooling to ensure there is one and only one empty newline between them.