### PR TITLE
Rename Output to Print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v0.2.0 - 2024/06/06
+
+- Added: `Print` struct. `Output` is now deprecated, use `Print` instead (https://github.com/schneems/bullet_stream/pull/5)
+- Fix: Missing `must_use` attributes (https://github.com/schneems/bullet_stream/pull/5)
+
 ## v0.1.1 - 2024/06/03
 
 - Fix double newlines for headers (https://github.com/schneems/bullet_stream/pull/2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "bullet_stream"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ascii_table",
  "fun_run",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bullet_stream"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Bulletproof printing for bullet point text"

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Add bullet_stream to your project:
 $ cargo add bullet_stream
 ```
 
-Now use [`Output`] to output structured text as a script/buildpack executes. The output
+Now use [`Print`] to output structured text as a script/buildpack executes. The output
 is intended to be read by the end user.
 
 ```rust
-use bullet_stream::Output;
+use bullet_stream::Print;
 
-let mut output = Output::new(std::io::stdout())
+let mut output = Print::new(std::io::stdout())
     .h2("Example Buildpack")
     .warning("No Gemfile.lock found");
 

--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -1,7 +1,6 @@
-// use commons::output::fmt::{self, DEBUG_INFO, HELP};
 use ascii_table::AsciiTable;
 #[allow(clippy::wildcard_imports)]
-use bullet_stream::{style, Output};
+use bullet_stream::{style, Print};
 use fun_run::CommandWithName;
 use indoc::formatdoc;
 use std::io::stdout;
@@ -10,7 +9,7 @@ use std::process::Command;
 #[allow(clippy::too_many_lines)]
 fn main() {
     {
-        let mut log = Output::new(stdout()).h1("Living build output style guide");
+        let mut log = Print::new(stdout()).h1("Living build output style guide");
         log = log.h2("Bullet section features");
         log = log
             .bullet("Bullet example")
@@ -66,7 +65,7 @@ fn main() {
         #[allow(clippy::unwrap_used)]
         let cmd_error = Command::new("iDoNotExist").named_output().err().unwrap();
 
-        let mut log = Output::new(stdout()).h2("Error and warnings");
+        let mut log = Print::new(stdout()).h2("Error and warnings");
         log = log
             .bullet("Debug information")
             .sub_bullet("Should go above errors in section/step format")
@@ -106,7 +105,7 @@ fn main() {
     }
 
     {
-        let log = Output::new(stdout()).h2("Formatting helpers");
+        let log = Print::new(stdout()).h2("Formatting helpers");
         log.bullet("The fmt module")
             .sub_bullet(formatdoc! {"
                 Formatting helpers can be used to enhance log output:

--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -4,6 +4,7 @@ use bullet_stream::{style, Print};
 use fun_run::CommandWithName;
 use indoc::formatdoc;
 use std::io::stdout;
+use std::io::Write;
 use std::process::Command;
 
 #[allow(clippy::too_many_lines)]
@@ -51,13 +52,7 @@ fn main() {
             |stdout, stderr| command.stream_output(stdout, stderr),
         );
 
-        sub_bullet.done();
-
-        // // TODO: Remove usage of unwrap(): https://github.com/heroku/buildpacks-ruby/issues/238
-        // #[allow(clippy::unwrap_used)]
-        // command.stream_output(stream.io(), stream.io()).unwrap();
-        // log = stream.finish_timed_stream().done();
-        // drop(log);
+        let _ = sub_bullet.done();
     }
 
     {
@@ -106,11 +101,9 @@ fn main() {
 
     {
         let log = Print::new(stdout()).h2("Formatting helpers");
-        log.bullet("The fmt module")
-            .sub_bullet(formatdoc! {"
-                Formatting helpers can be used to enhance log output:
-            "})
-            .done();
+        let mut stream = log
+            .bullet("The fmt module")
+            .start_stream("Formatting helpers can be used to enhance log output:");
 
         let mut table = AsciiTable::default();
         table.set_max_width(240);
@@ -146,6 +139,8 @@ fn main() {
             ],
         ];
 
-        table.print(data);
+        write!(stream, "{}", table.format(data)).unwrap();
+
+        stream.done().done().done();
     }
 }


### PR DESCRIPTION
When trying to use both `std::process::Output` and `bullet_stream::Output` in the same file there is an import collision.

With this change the `Print`  struct is introduced. The `Output` struct is still available but is deprecated.

Close #4